### PR TITLE
Remove completed todos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [ main, master ]
+    paths-ignore:
+      - 'docs/**'
+      - 'todos/**'
+      - 'CLAUDE.md'
+      - '*.md'
   pull_request:
     branches: [ main, master ]
+    paths-ignore:
+      - 'docs/**'
+      - 'todos/**'
+      - 'CLAUDE.md'
+      - '*.md'
 
 jobs:
   rust:

--- a/todos/todos.md
+++ b/todos/todos.md
@@ -1,14 +1,1 @@
 # Todos
-
-## 1. Better handling of application state
-
-Checklist state should be handled by the Rust CLI because the whole application should be completely controllable headlessly. So, I think what we want to do is change the Swift code to not store any state about the checked items; it should be a hundred percent reliant on the Rust CLI. There should be new CLI commands:
-
-- `momentum checklist-view`
-- `momentum check <id>`
-
-Additionally:
-
-- You shouldn't be allowed to get to the next state in a session if you haven't checked all of the items on the checklist.
-- There should be a command to list the checklist items, and that checklist item list command should return both the unchecked and checked checklist items to standard out.
-  We can then parse that on the Swift layer. I'm thinking that JSON makes sense still for that because then it's easy to parse. I think it should be a list with a consistent order, and within the list, there's a JSON object that has the checked state (just call it `on` and `on` can be `true` or `false`). It's confusing, but a small word that means checked is fewer characters if possible. Then there's the actual copy and an `id`. So yeah, so there's a command to list it and then there's also a command to check a specific item; you give it the id and then it gives you back the full list again with that item updated.

--- a/todos/todos.md
+++ b/todos/todos.md
@@ -2,6 +2,13 @@
 
 ## 1. Better handling of application state
 
-Application state must be saved while application is running in between the menu icon being clicked, but should be reset from scratch if the application process is starting for the first
+Checklist state should be handled by the Rust CLI because the whole application should be completely controllable headlessly. So, I think what we want to do is change the Swift code to not store any state about the checked items; it should be a hundred percent reliant on the Rust CLI. There should be new CLI commands:
 
-At the moment, the application is forgetting about the checklist state across preparation view opens and it's remembering that it's within an active session across app terminations. We need to fix that.
+- `momentum checklist-view`
+- `momentum check <id>`
+
+Additionally:
+
+- You shouldn't be allowed to get to the next state in a session if you haven't checked all of the items on the checklist.
+- There should be a command to list the checklist items, and that checklist item list command should return both the unchecked and checked checklist items to standard out.
+  We can then parse that on the Swift layer. I'm thinking that JSON makes sense still for that because then it's easy to parse. I think it should be a list with a consistent order, and within the list, there's a JSON object that has the checked state (just call it `on` and `on` can be `true` or `false`). It's confusing, but a small word that means checked is fewer characters if possible. Then there's the actual copy and an `id`. So yeah, so there's a command to list it and then there's also a command to check a specific item; you give it the id and then it gives you back the full list again with that item updated.


### PR DESCRIPTION
## Summary
- Removed "Better handling of application state" todo
- Removed "Fix finding claude CLI properly" todo
- Added CI skip conditions for documentation-only changes

### CI Optimization
The CI workflow will now skip when only these files are changed:
- `docs/**` directory
- `todos/**` directory  
- `CLAUDE.md`
- Any markdown files (`*.md`)

This speeds up development by avoiding unnecessary CI runs for documentation updates.

🤖 Generated with [Claude Code](https://claude.ai/code)