### PR TITLE
Implement Swift-based Claude analysis

### DIFF
--- a/MomentumApp/Sources/Dependencies/ProcessRunner.swift
+++ b/MomentumApp/Sources/Dependencies/ProcessRunner.swift
@@ -29,8 +29,8 @@ struct ProcessRunner: DependencyKey {
             let analysisJson = """
                 {
                     "summary": "Test analysis summary",
-                    "suggestion": "Test suggestion",
-                    "reasoning": "Test reasoning"
+                    "suggestions": "Test suggestions",
+                    "questions": "Test questions"
                 }
                 """
             return ProcessResult(

--- a/MomentumApp/Sources/Models/RustCoreModels.swift
+++ b/MomentumApp/Sources/Models/RustCoreModels.swift
@@ -28,8 +28,8 @@ struct SessionData: Equatable, Codable {
 
 struct AnalysisResult: Equatable, Codable {
     let summary: String
-    let suggestion: String
-    let reasoning: String
+    let suggestions: String
+    let questions: String
 }
 
 // MARK: - Checklist Models

--- a/MomentumApp/Sources/Views/AnalysisResultView.swift
+++ b/MomentumApp/Sources/Views/AnalysisResultView.swift
@@ -27,13 +27,13 @@ struct AnalysisResultView: View {
                             .padding(.horizontal, .momentumSpacingSmall)
                     }
 
-                    // Suggestion section
+                    // Actionable suggestions section
                     VStack(alignment: .leading, spacing: .momentumSpacingMedium) {
-                        Text("SUGGESTION")
+                        Text("ACTIONABLE SUGGESTIONS")
                             .font(.sectionLabel)
                             .foregroundStyle(Color.textSecondary)
 
-                        Text(store.analysis.suggestion)
+                        Text(store.analysis.suggestions)
                             .font(.system(size: 14))
                             .foregroundStyle(Color.textPrimary)
                             .lineSpacing(4)
@@ -41,13 +41,13 @@ struct AnalysisResultView: View {
                             .padding(.horizontal, .momentumSpacingSmall)
                     }
 
-                    // Reasoning section
+                    // Deeper questions section
                     VStack(alignment: .leading, spacing: .momentumSpacingMedium) {
-                        Text("REASONING")
+                        Text("DEEPER QUESTIONS")
                             .font(.sectionLabel)
                             .foregroundStyle(Color.textSecondary)
 
-                        Text(store.analysis.reasoning)
+                        Text(store.analysis.questions)
                             .font(.system(size: 14))
                             .foregroundStyle(Color.textPrimary)
                             .lineSpacing(4)

--- a/MomentumApp/Tests/FullFlowTests.swift
+++ b/MomentumApp/Tests/FullFlowTests.swift
@@ -49,8 +49,8 @@ struct FullFlowTests {
             $0.a4Client.analyze = { _ in
                 AnalysisResult(
                     summary: "Test analysis summary",
-                    suggestion: "Test suggestion",
-                    reasoning: "Test reasoning"
+                    suggestions: "Test suggestions",
+                    questions: "Test questions"
                 )
             }
             $0.a4Client.checkList = {
@@ -134,8 +134,8 @@ struct FullFlowTests {
                                 .analysisRequested(
                                     analysisResult: AnalysisResult(
                                         summary: "Test analysis summary",
-                                        suggestion: "Test suggestion",
-                                        reasoning: "Test reasoning"
+                                        suggestions: "Test suggestions",
+                                        questions: "Test questions"
                                     ))))))
             ) {
                 $0.isLoading = false
@@ -145,8 +145,8 @@ struct FullFlowTests {
                     AnalysisFeature.State(
                         analysis: AnalysisResult(
                             summary: "Test analysis summary",
-                            suggestion: "Test suggestion",
-                            reasoning: "Test reasoning"
+                            suggestions: "Test suggestions",
+                            questions: "Test questions"
                         )))
             }
 

--- a/MomentumApp/Tests/ReflectionFeatureTests.swift
+++ b/MomentumApp/Tests/ReflectionFeatureTests.swift
@@ -10,8 +10,8 @@ struct ReflectionFeatureTests {
     func analyzeReflection_Success() async {
         let analysisResult = AnalysisResult(
             summary: "Test summary",
-            suggestion: "Test suggestion",
-            reasoning: "Test reasoning"
+            suggestions: "Test suggestions",
+            questions: "Test questions"
         )
 
         let store = TestStore(

--- a/MomentumApp/Tests/TestHelpers.swift
+++ b/MomentumApp/Tests/TestHelpers.swift
@@ -65,8 +65,8 @@ extension SessionData {
 extension AnalysisResult {
     static let mock = AnalysisResult(
         summary: "Test Summary",
-        suggestion: "Test Suggestion",
-        reasoning: "Test Reasoning"
+        suggestions: "Test Suggestions",
+        questions: "Test Questions"
     )
 }
 


### PR DESCRIPTION
## Summary
- replace the Rust CLI-dependent analysis with a Swift zsh command that calls the claude CLI
- update analysis parsing, reflection markdown, and UI to show summary/suggestions/questions
- refresh AnalysisResult model plus tests to match the new response format

## Testing
- make swift-test
