### PR TITLE
Add approach/timeout menu bar cues

### DIFF
--- a/MomentumApp/Sources/AppFeature+State.swift
+++ b/MomentumApp/Sources/AppFeature+State.swift
@@ -4,6 +4,8 @@ import Observation
 import Sharing
 
 extension AppFeature {
+    enum MenuBarPhase: Equatable { case normal, approach, timeout }
+
     @ObservableState
     struct State: Equatable {
         @Shared(.sessionData) var sessionData: SessionData? = nil
@@ -15,6 +17,7 @@ extension AppFeature {
 
         var isLoading = false
         var reflectionPath: String?
+        var menuBarPhase: MenuBarPhase = .normal
 
         init() {
             // Initialize destination based on shared state

--- a/MomentumApp/Sources/Dependencies/TestServerClient.swift
+++ b/MomentumApp/Sources/Dependencies/TestServerClient.swift
@@ -291,6 +291,11 @@ import Network
     extension Notification.Name {
         static let testServerShowMenu = Notification.Name("testServerShowMenu")
         static let testServerRefreshState = Notification.Name("testServerRefreshState")
+        static let menuBarSetApproachIcon = Notification.Name("menuBarSetApproachIcon")
+        static let menuBarSetTimeoutIcon = Notification.Name("menuBarSetTimeoutIcon")
+        static let menuBarSetNormalIcon = Notification.Name("menuBarSetNormalIcon")
+        static let showApproachMicroPopover = Notification.Name("showApproachMicroPopover")
+        static let showTimeoutMicroPopover = Notification.Name("showTimeoutMicroPopover")
     }
 
     // MARK: - Test Logger

--- a/MomentumApp/Sources/Features/ActiveSession/ActiveSessionFeature.swift
+++ b/MomentumApp/Sources/Features/ActiveSession/ActiveSessionFeature.swift
@@ -11,6 +11,8 @@ struct ActiveSessionFeature {
         let startTime: Date
         let expectedMinutes: UInt64
         var operationError: String?
+        var hasApproachEventFired = false
+        var hasTimeoutEventFired = false
     }
 
     enum Action: Equatable {
@@ -18,18 +20,24 @@ struct ActiveSessionFeature {
         case performStop
         case stopSessionResponse(TaskResult<String>)
         case clearOperationError
+        case startTimers
+        case approachTimerFired
+        case timeoutTimerFired
+        case cancelTimers
         case delegate(Delegate)
 
         enum Delegate: Equatable {
             case sessionStopped(reflectionPath: String)
             case sessionFailedToStop(AppError)
+            case approachFired
+            case timeoutFired
         }
     }
 
     @Dependency(\.a4Client) var a4Client
     @Dependency(\.continuousClock) var clock
 
-    enum CancelID { case errorDismissal }
+    enum CancelID { case errorDismissal, approachTimer, timeoutTimer }
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -50,7 +58,13 @@ struct ActiveSessionFeature {
                 }
 
             case let .stopSessionResponse(.success(reflectionPath)):
-                return .send(.delegate(.sessionStopped(reflectionPath: reflectionPath)))
+                state.hasApproachEventFired = false
+                state.hasTimeoutEventFired = false
+                return .merge(
+                    .cancel(id: CancelID.approachTimer),
+                    .cancel(id: CancelID.timeoutTimer),
+                    .send(.delegate(.sessionStopped(reflectionPath: reflectionPath)))
+                )
 
             case let .stopSessionResponse(.failure(error)):
                 state.operationError = error.localizedDescription
@@ -65,6 +79,73 @@ struct ActiveSessionFeature {
             case .clearOperationError:
                 state.operationError = nil
                 return .none
+
+            case .startTimers:
+                let totalSeconds = TimeInterval(state.expectedMinutes) * 60
+                let approachLeadSeconds: TimeInterval = totalSeconds <= 7 * 60 ? 2 * 60 : 5 * 60
+                let sessionEnd = state.startTime.addingTimeInterval(totalSeconds)
+                let now = Date()
+                let remainingSeconds = sessionEnd.timeIntervalSince(now)
+
+                // If the session appears to already be over, immediately emit timeout
+                if remainingSeconds <= 0 {
+                    state.hasTimeoutEventFired = true
+                    state.hasApproachEventFired = true
+                    return .send(.delegate(.timeoutFired))
+                }
+
+                var effects: [Effect<Action>] = []
+
+                if !state.hasApproachEventFired {
+                    let approachDelay = remainingSeconds - approachLeadSeconds
+                    if approachDelay <= 0 {
+                        state.hasApproachEventFired = true
+                        effects.append(.send(.delegate(.approachFired)))
+                    } else {
+                        effects.append(
+                            .run { send in
+                                try await clock.sleep(for: .seconds(approachDelay))
+                                await send(.approachTimerFired)
+                            }
+                            .cancellable(id: CancelID.approachTimer, cancelInFlight: true)
+                        )
+                    }
+                }
+
+                if !state.hasTimeoutEventFired {
+                    effects.append(
+                        .run { send in
+                            try await clock.sleep(for: .seconds(remainingSeconds))
+                            await send(.timeoutTimerFired)
+                        }
+                        .cancellable(id: CancelID.timeoutTimer, cancelInFlight: true)
+                    )
+                }
+
+                return .merge(effects)
+
+            case .approachTimerFired:
+                if state.hasApproachEventFired {
+                    return .none
+                }
+                state.hasApproachEventFired = true
+                return .send(.delegate(.approachFired))
+
+            case .timeoutTimerFired:
+                if state.hasTimeoutEventFired {
+                    return .none
+                }
+                state.hasTimeoutEventFired = true
+                return .merge(
+                    .cancel(id: CancelID.approachTimer),
+                    .send(.delegate(.timeoutFired))
+                )
+
+            case .cancelTimers:
+                return .merge(
+                    .cancel(id: CancelID.approachTimer),
+                    .cancel(id: CancelID.timeoutTimer)
+                )
 
             case .delegate:
                 return .none

--- a/MomentumApp/Tests/ActiveSessionFeatureTests.swift
+++ b/MomentumApp/Tests/ActiveSessionFeatureTests.swift
@@ -60,4 +60,5 @@ struct ActiveSessionFeatureTests {
             $0.operationError = nil
         }
     }
+
 }


### PR DESCRIPTION
## Summary
- schedule reducer-driven approach and timeout events so menu bar icon and micro-popovers fire with five (or two) minutes remaining
- swap status item icons via notifications and introduce transient micro-popover with auto-dismiss
- keep existing popover intact while wiring AppDelegate observers for new cues

## Testing
- make swift-test